### PR TITLE
Adding missing tallies to the OpenMC Sphere benchmark.

### DIFF
--- a/jade_open_benchmarks/inputs/Sphere/Sphere/openmc/tallies.xml
+++ b/jade_open_benchmarks/inputs/Sphere/Sphere/openmc/tallies.xml
@@ -30,6 +30,9 @@
   <filter id="21" type="energy">
     <bins> 1e-05 1 100000 1000000 10000000 20000000</bins>
   </filter>
+    <filter id="6" type="material">
+    <bins>1</bins>
+  </filter>
   <tally id="2" name="Neutron Flux at the external surface in Vitamin-J 175 energy groups">
     <filters>1 3 13</filters>
     <scores>flux</scores>
@@ -61,5 +64,17 @@
   <tally id="12" name="Neutron Flux at the external surface in course energy groups">
     <filters>1 3 21</filters>
     <scores>flux</scores>
+  </tally>
+    <tally id="14" name="He ppm production">
+    <filters>23 6 3</filters>
+    <scores>He4-production</scores>
+  </tally>
+  <tally id="24" name="T production">
+    <filters>23 6 3</filters>
+    <scores>H3-production</scores>
+  </tally>
+  <tally id="34" name="DPA production">
+    <filters>23 6 3</filters>
+    <scores>damage-energy</scores>
   </tally>
 </tallies>

--- a/jade_open_benchmarks/inputs/Sphere/benchmark_metadata.json
+++ b/jade_open_benchmarks/inputs/Sphere/benchmark_metadata.json
@@ -2,7 +2,7 @@
     "name": "Sphere",
     "version": {
         "mcnp": "1.0",
-        "openmc": "1.0",
+        "openmc": "2.0",
         "serpent": "1.0"
     }
 }


### PR DESCRIPTION
The addition of 3 more tallies, ID: 14,24,34, that match up with the MCNP tallies. Post processing is handled within JADE engine to make the results equivalent.